### PR TITLE
frontplate-cli v.4.2.0 でsasslintエラーが出ているのを修正

### DIFF
--- a/src/sass/layout/_layout.scss
+++ b/src/sass/layout/_layout.scss
@@ -1,5 +1,4 @@
 .clearfix {
-  *zoom: 1;
   &:before, &:after {
     content: " ";
     display: table;


### PR DESCRIPTION
IE 6, 7に対するハックなので、デフォルトでは不要かと思いました。